### PR TITLE
Excepcion carpeta SonarQube

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,6 +31,7 @@ build/
 
 ### VS Code ###
 .vscode/
+.scannerwork/
 
 ### MAC OS ###
 .DS_Store


### PR DESCRIPTION
No incluir carpeta .scannerwork generada por SonarQube